### PR TITLE
Add AltStore source caching

### DIFF
--- a/LiveContainerSwiftUI/LCSourcesView.swift
+++ b/LiveContainerSwiftUI/LCSourcesView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+struct AltStoreVersion: Codable {
+    let version: String?
+    let downloadURL: String?
+}
+
+struct AltStoreApp: Codable, Identifiable {
+    var id: String { bundleIdentifier }
+    let name: String
+    let bundleIdentifier: String
+    let developerName: String?
+    let subtitle: String?
+    let iconURL: String?
+    let versions: [AltStoreVersion]?
+    let version: String?
+    let downloadURL: String?
+
+    var latestDownloadURL: String? {
+        if let versions, let first = versions.first {
+            return first.downloadURL
+        }
+        return downloadURL
+    }
+}
+
+struct AltStoreSource: Codable {
+    let name: String
+    let identifier: String
+    let apps: [AltStoreApp]
+}
+
+struct AltStoreAppBanner: View {
+    let app: AltStoreApp
+
+    var body: some View {
+        HStack {
+            if let icon = app.iconURL, let url = URL(string: icon) {
+                AsyncImage(url: url) { image in
+                    image.resizable()
+                } placeholder: {
+                    Color.gray
+                }
+                .frame(width: 60, height: 60)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            } else {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: 60, height: 60)
+            }
+
+            VStack(alignment: .leading) {
+                Text(app.name)
+                    .font(.system(size: 16).bold())
+                if let subtitle = app.subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 12))
+                        .foregroundColor(Color("FontColor"))
+                }
+            }
+
+            Spacer()
+
+            if let download = app.latestDownloadURL,
+               let encoded = download.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+               let dlUrl = URL(string: "livecontainer://install?url=\(encoded)") {
+                Button {
+                    UIApplication.shared.open(dlUrl)
+                } label: {
+                    Text("Download")
+                        .bold()
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                        .frame(height: 32)
+                }
+                .buttonStyle(BasicButtonStyle())
+                .padding()
+                .frame(idealWidth: 70)
+                .frame(height: 32)
+                .fixedSize()
+                .background(Capsule().fill(Color("FontColor")))
+                .clipShape(Capsule())
+            }
+        }
+        .padding()
+        .frame(height: 88)
+        .background(
+            RoundedRectangle(cornerRadius: 22)
+                .fill(Color("AppBannerBG"))
+        )
+    }
+}
+
+struct LCSourcesView: View {
+    @State private var sourceURLs: [String] = []
+    @State private var sources: [String: AltStoreSource] = [:]
+    @State private var loadingSources: Set<String> = []
+    @State private var error: String?
+
+    @StateObject private var addSourceInput = InputHelper()
+
+    private let defaultSource = "https://raw.githubusercontent.com/LiveContainer/LiveContainer/main/apps.json"
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    ForEach(sourceURLs, id: \.self) { url in
+                        if let source = sources[url] {
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    Text(source.name)
+                                        .font(.system(.title2).bold())
+                                    Spacer()
+                                    Menu {
+                                        Button(role: .destructive) {
+                                            removeSource(url: url)
+                                        } label: {
+                                            Label("lc.common.delete".loc, systemImage: "trash")
+                                        }
+                                    } label: {
+                                        Image(systemName: "ellipsis.circle")
+                                            .font(.title3)
+                                    }
+                                }
+
+                                ForEach(source.apps) { app in
+                                    AltStoreAppBanner(app: app)
+                                }
+                            }
+                        } else if loadingSources.contains(url) {
+                            ProgressView()
+                                .padding()
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("lc.tabView.sources".loc)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { Task { if let new = await addSourceInput.open(), let new = new, !new.isEmpty { addSource(url: new) } } }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .textFieldAlert(
+                isPresented: $addSourceInput.show,
+                title: "Enter Source URL",
+                text: $addSourceInput.initVal,
+                placeholder: "https://",
+                action: { addSourceInput.close(result: $0) },
+                actionCancel: { _ in addSourceInput.close(result: nil) }
+            )
+            .onAppear {
+                if sourceURLs.isEmpty { loadSourceList() }
+            }
+            .alert(isPresented: Binding<Bool>(get: { error != nil }, set: { _ in error = nil })) {
+                Alert(title: Text("Error"), message: Text(error ?? ""), dismissButton: .default(Text("OK")))
+            }
+        }
+    }
+
+    private func loadSourceList() {
+        sourceURLs = UserDefaults.standard.stringArray(forKey: "LCSources") ?? [defaultSource]
+        for url in sourceURLs {
+            loadCachedSource(url: url)
+            fetchSource(url: url)
+        }
+    }
+
+    private func saveSourceList() {
+        UserDefaults.standard.set(sourceURLs, forKey: "LCSources")
+    }
+
+    private func cachePath(for url: String) -> URL {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let folder = caches.appendingPathComponent("LCSources", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: folder.path) {
+            try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        }
+        let name = Data(url.utf8).base64EncodedString()
+        return folder.appendingPathComponent(name)
+    }
+
+    private func loadCachedSource(url: String) {
+        let path = cachePath(for: url)
+        if let data = try? Data(contentsOf: path),
+           let src = try? JSONDecoder().decode(AltStoreSource.self, from: data) {
+            self.sources[url] = src
+        }
+    }
+
+    private func saveCachedSource(url: String, data: Data) {
+        let path = cachePath(for: url)
+        try? data.write(to: path)
+    }
+
+    private func fetchSource(url: String) {
+        guard let u = URL(string: url) else { return }
+        loadingSources.insert(url)
+        Task {
+            do {
+                let data = try Data(contentsOf: u)
+                let src = try JSONDecoder().decode(AltStoreSource.self, from: data)
+                await MainActor.run {
+                    self.sources[url] = src
+                    self.saveCachedSource(url: url, data: data)
+                    self.loadingSources.remove(url)
+                }
+            } catch {
+                await MainActor.run {
+                    if self.sources[url] == nil {
+                        self.error = error.localizedDescription
+                    }
+                    self.loadingSources.remove(url)
+                }
+            }
+        }
+    }
+
+    private func addSource(url: String) {
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if !sourceURLs.contains(trimmed) {
+            sourceURLs.append(trimmed)
+            saveSourceList()
+            fetchSource(url: trimmed)
+        }
+    }
+
+    private func removeSource(url: String) {
+        sourceURLs.removeAll { $0 == url }
+        sources.removeValue(forKey: url)
+        let path = cachePath(for: url)
+        try? FileManager.default.removeItem(at: path)
+        saveSourceList()
+    }
+}

--- a/LiveContainerSwiftUI/LCSourcesView.swift
+++ b/LiveContainerSwiftUI/LCSourcesView.swift
@@ -32,6 +32,7 @@ struct AltStoreSource: Codable {
 
 struct AltStoreAppBanner: View {
     let app: AltStoreApp
+    @EnvironmentObject var model: SharedModel
 
     var body: some View {
         HStack {
@@ -66,20 +67,17 @@ struct AltStoreAppBanner: View {
                let dlUrl = URL(string: "livecontainer://install?url=\(encoded)") {
                 Button {
                     UIApplication.shared.open(dlUrl)
+                    model.selectedTab = 1
                 } label: {
                     Text("Download")
                         .bold()
                         .foregroundColor(.white)
-                        .lineLimit(1)
                         .frame(height: 32)
+                        .padding(.horizontal, 12)
                 }
                 .buttonStyle(BasicButtonStyle())
-                .padding()
-                .frame(idealWidth: 70)
-                .frame(height: 32)
-                .fixedSize()
                 .background(Capsule().fill(Color("FontColor")))
-                .clipShape(Capsule())
+                .padding()
             }
         }
         .padding()

--- a/LiveContainerSwiftUI/LCSourcesView.swift
+++ b/LiveContainerSwiftUI/LCSourcesView.swift
@@ -139,7 +139,7 @@ struct LCSourcesView: View {
             .navigationTitle("lc.tabView.sources".loc)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: { Task { if let new = await addSourceInput.open(), let new = new, !new.isEmpty { addSource(url: new) } } }) {
+                    Button(action: { Task { if let new = await addSourceInput.open(), !new.isEmpty { addSource(url: new) } } }) {
                         Image(systemName: "plus")
                     }
                 }

--- a/LiveContainerSwiftUI/LCTabView.swift
+++ b/LiveContainerSwiftUI/LCTabView.swift
@@ -16,31 +16,42 @@ struct LCTabView: View {
     @State var errorInfo = ""
     
     @EnvironmentObject var sceneDelegate: SceneDelegate
+    @EnvironmentObject var model: SharedModel
     @State var shouldToggleMainWindowOpen = false
     @Environment(\.scenePhase) var scenePhase
     let pub = NotificationCenter.default.publisher(for: UIScene.didDisconnectNotification)
     
     var body: some View {
-        TabView {
+        TabView(selection: $model.selectedTab) {
             LCSourcesView()
                 .tabItem {
                     Label("lc.tabView.sources".loc, systemImage: "tray.and.arrow.down")
                 }
+                .tag(0)
             LCAppListView(appDataFolderNames: $appDataFolderNames, tweakFolderNames: $tweakFolderNames)
                 .tabItem {
                     Label("lc.tabView.apps".loc, systemImage: "square.stack.3d.up.fill")
                 }
+                .tag(1)
             if DataManager.shared.model.multiLCStatus != 2 {
                 LCTweaksView(tweakFolders: $tweakFolderNames)
                     .tabItem{
                         Label("lc.tabView.tweaks".loc, systemImage: "wrench.and.screwdriver")
                     }
-            }
+                    .tag(2)
 
-            LCSettingsView(appDataFolderNames: $appDataFolderNames)
-                .tabItem {
-                    Label("lc.tabView.settings".loc, systemImage: "gearshape.fill")
-                }
+                LCSettingsView(appDataFolderNames: $appDataFolderNames)
+                    .tabItem {
+                        Label("lc.tabView.settings".loc, systemImage: "gearshape.fill")
+                    }
+                    .tag(3)
+            } else {
+                LCSettingsView(appDataFolderNames: $appDataFolderNames)
+                    .tabItem {
+                        Label("lc.tabView.settings".loc, systemImage: "gearshape.fill")
+                    }
+                    .tag(2)
+            }
         }
         .alert("lc.common.error".loc, isPresented: $errorShow){
             Button("lc.common.ok".loc, action: {

--- a/LiveContainerSwiftUI/LCTabView.swift
+++ b/LiveContainerSwiftUI/LCTabView.swift
@@ -22,6 +22,10 @@ struct LCTabView: View {
     
     var body: some View {
         TabView {
+            LCSourcesView()
+                .tabItem {
+                    Label("lc.tabView.sources".loc, systemImage: "tray.and.arrow.down")
+                }
             LCAppListView(appDataFolderNames: $appDataFolderNames, tweakFolderNames: $tweakFolderNames)
                 .tabItem {
                     Label("lc.tabView.apps".loc, systemImage: "square.stack.3d.up.fill")

--- a/LiveContainerSwiftUI/LCTabView.swift
+++ b/LiveContainerSwiftUI/LCTabView.swift
@@ -74,7 +74,6 @@ struct LCTabView: View {
                 }
             }
         }
-        .environmentObject(DataManager.shared.model)
     }
     
     func closeDuplicatedWindow() {

--- a/LiveContainerSwiftUI/LiveContainerSwiftUIApp.swift
+++ b/LiveContainerSwiftUI/LiveContainerSwiftUIApp.swift
@@ -88,6 +88,7 @@ struct LiveContainerSwiftUIApp : App {
     var body: some Scene {
         WindowGroup(id: "Main") {
             LCTabView(appDataFolderNames: $appDataFolderNames, tweakFolderNames: $tweakFolderNames)
+                .environmentObject(DataManager.shared.model)
                 .handlesExternalEvents(preferring: ["*"], allowing: ["*"])
             if #available(iOS 16.1, *) {
                 GetOpenWindowActionView()

--- a/LiveContainerSwiftUI/Shared.swift
+++ b/LiveContainerSwiftUI/Shared.swift
@@ -61,6 +61,9 @@ class SharedModel: ObservableObject {
     @AppStorage("LCCertificateImported") var certificateImported = false
     
     @Published var enableMultipleWindow = false
+
+    /// Currently selected tab index in ``LCTabView``
+    @Published var selectedTab = 0
     
     @Published var apps : [LCAppModel] = []
     @Published var hiddenApps : [LCAppModel] = []

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -15631,6 +15631,21 @@
         }
       }
     },
+    "lc.tabView.sources" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "sv" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "Sources" } }
+      }
+    },
     "lc.tweakView.appFolderDesc" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary
- cache the contents of each AltStore source to disk
- load cached data before fetching new data
- remove cached data when a source is deleted
- refine Sources tab UI to mirror existing app list style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684221ce6668832d94bc08081f559d43