### PR TITLE
Ensure defaults saved on quit

### DIFF
--- a/LiveContainerSwiftUI/AppDelegate.swift
+++ b/LiveContainerSwiftUI/AppDelegate.swift
@@ -13,12 +13,15 @@ import SwiftUI
                 UserDefaults.standard.removeObject(forKey: "selected")
                 UserDefaults.standard.removeObject(forKey: "selectedContainer")
             }
-            
+
             if (UserDefaults.standard.object(forKey: "LCLastLanguages") != nil) {
                 // recover livecontainer's own language
                 UserDefaults.standard.set(UserDefaults.standard.object(forKey: "LCLastLanguages"), forKey: "AppleLanguages")
                 UserDefaults.standard.removeObject(forKey: "LCLastLanguages")
             }
+
+            // Ensure any changes are flushed to disk so the last opened tab is restored
+            UserDefaults.standard.synchronize()
         }
         return true
     }


### PR DESCRIPTION
## Summary
- flush UserDefaults when the app terminates so the last tab state persists

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684238c705e8832d93f7ada1c6abe277