### PR TITLE
Update tab behavior and ipad layout

### DIFF
--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -85,7 +85,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             .labelsHidden()
                             .scaleEffect(y: 0.5)
                         if totalInstallCount > 1 {
-                            Text("\(currentInstallIndex) of \(totalInstallCount)")
+                            Text("\(currentInstallIndex) / \(totalInstallCount)")
                                 .font(.caption2.monospacedDigit())
                         }
                     }
@@ -176,6 +176,10 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             .onAppear {
                 if !didAppear {
                     onAppear()
+                }
+                if let url = sharedModel.pendingOpenURL {
+                    handleURL(url: url)
+                    sharedModel.pendingOpenURL = nil
                 }
             }
             
@@ -300,6 +304,12 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         .onOpenURL { url in
             handleURL(url: url)
         }
+        .onChange(of: sharedModel.pendingOpenURL) { newValue in
+            if let url = newValue {
+                handleURL(url: url)
+                sharedModel.pendingOpenURL = nil
+            }
+        }
 
     }
     
@@ -342,6 +352,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                     }
                 }
             }
+            .navigationViewStyle(StackNavigationViewStyle())
         }
     }
     

--- a/LiveContainerSwiftUI/LCHelpView.swift
+++ b/LiveContainerSwiftUI/LCHelpView.swift
@@ -29,6 +29,7 @@ struct LCHelpView : View {
                     }
                 }
             }
+            .navigationViewStyle(StackNavigationViewStyle())
         }
     }
 }

--- a/LiveContainerSwiftUI/LCSelectContainerView.swift
+++ b/LiveContainerSwiftUI/LCSelectContainerView.swift
@@ -58,6 +58,7 @@ struct LCSelectContainerView : View{
             }
             .navigationTitle(Text("lc.container.selectUnused".loc))
             .navigationBarTitleDisplayMode(.inline)
+            .navigationViewStyle(StackNavigationViewStyle())
         }
         .onAppear() {
             loadUnusedContainers()

--- a/LiveContainerSwiftUI/LCSourcesView.swift
+++ b/LiveContainerSwiftUI/LCSourcesView.swift
@@ -250,6 +250,7 @@ struct LCSourcesView: View {
             .alert(isPresented: Binding<Bool>(get: { error != nil }, set: { _ in error = nil })) {
                 Alert(title: Text("Error"), message: Text(error ?? ""), dismissButton: .default(Text("OK")))
             }
+            .navigationViewStyle(StackNavigationViewStyle())
         }
     }
 

--- a/LiveContainerSwiftUI/LCTabView.swift
+++ b/LiveContainerSwiftUI/LCTabView.swift
@@ -23,11 +23,14 @@ struct LCTabView: View {
     
     var body: some View {
         TabView(selection: $model.selectedTab) {
-            LCSourcesView()
-                .tabItem {
-                    Label("lc.tabView.sources".loc, systemImage: "tray.and.arrow.down")
-                }
-                .tag(0)
+            if DataManager.shared.model.multiLCStatus != 2 {
+                LCSourcesView()
+                    .tabItem {
+                        Label("lc.tabView.sources".loc, systemImage: "tray.and.arrow.down")
+                    }
+                    .tag(0)
+            }
+
             LCAppListView(appDataFolderNames: $appDataFolderNames, tweakFolderNames: $tweakFolderNames)
                 .tabItem {
                     Label("lc.tabView.apps".loc, systemImage: "square.stack.3d.up.fill")
@@ -73,6 +76,10 @@ struct LCTabView: View {
                     DataManager.shared.model.mainWindowOpened = false
                 }
             }
+        }
+        .onOpenURL { url in
+            model.pendingOpenURL = url
+            model.selectedTab = 1
         }
     }
     

--- a/LiveContainerSwiftUI/Shared.swift
+++ b/LiveContainerSwiftUI/Shared.swift
@@ -63,11 +63,20 @@ class SharedModel: ObservableObject {
     @Published var enableMultipleWindow = false
 
     /// Currently selected tab index in ``LCTabView``
-    @Published var selectedTab = UserDefaults.standard.integer(forKey: "LCSelectedTab") {
+    @Published var selectedTab: Int = {
+        if UserDefaults.standard.object(forKey: "LCSelectedTab") != nil {
+            return UserDefaults.standard.integer(forKey: "LCSelectedTab")
+        } else {
+            return 1
+        }
+    }() {
         didSet {
             UserDefaults.standard.set(selectedTab, forKey: "LCSelectedTab")
         }
     }
+
+    /// URL passed in via openURL when ``LCTabView`` isn't active yet
+    @Published var pendingOpenURL: URL? = nil
     
     @Published var apps : [LCAppModel] = []
     @Published var hiddenApps : [LCAppModel] = []


### PR DESCRIPTION
## Summary
- default to the Apps tab on first launch
- hide Sources tab when running as LiveContainer2
- process URL scheme actions even when not on the Apps tab
- adapt remaining views for iPad with `StackNavigationViewStyle`
- display install progress as `current / total`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68424d78241c832da4c2a87726c3e60a